### PR TITLE
fix(mod): handle case where mod decl exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
 - Made the `mod` snippet handle the case where the module declaration already
   exists.
+  Thanks [@gregorias](https://github.com/gregorias)!
 
 ## [1.4.1] - 2023-12-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.4.2] - 2023-12-09
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Made the `mod` snippet handle the case where the module declaration already
+  exists.
+
 ## [1.4.1] - 2023-12-05
 
 ### Fixed

--- a/lua/haskell-snippets/util.lua
+++ b/lua/haskell-snippets/util.lua
@@ -73,7 +73,11 @@ local get_clients = vim.lsp.get_clients or vim.lsp.get_active_clients
 function util.lsp_get_module_name()
   if #get_clients { bufnr = 0 } > 0 then
     for _, lens in pairs(vim.lsp.codelens.get(0)) do
-      local name = lens.command.title:match('module (.*) where')
+      -- Strings to match taken from the module name plugin:
+      -- https://github.com/haskell/haskell-language-server/blob/f0c16469046bd554828ea057b5e1f047ad02348e/plugins/hls-module-name-plugin/src/Ide/Plugin/ModuleName.hs#L129-L136
+      local name_module_decl_absent = lens.command.title:match('module (.*) where')
+      local name_module_decl_present = lens.command.title:match('Set module name to (.*)')
+      local name = name_module_decl_absent or name_module_decl_present
       if name then
         return name
       end


### PR DESCRIPTION
<!-- markdownlint-disable -->
###### Description of changes

Added another string to LSP get buf name utility.

I believe it makes sense that the `mod` snippet works even if there's an existing (potentially faulty) module declaration.

I reached this case myself, where I didn't have code lens displayed in Neovim, and tried to use a snippet to fix the module name.

###### Things done

- [x] Tested, as applicable:
  - [x] Manually
  - [ ] Added tests
- [x] Updated [CHANGELOG.md](https://github.com/mrcjkb/haskell-snippets.nvim/blob/master/CHANGELOG.md)
  (if applicable).
- [x] Fits [CONTRIBUTING.md](https://github.com/mrcjkb/haskell-snippets.nvim/blob/master/CONTRIBUTING.md)
