### PR TITLE
feat: add Haddock documentation snippets with smart detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `fdoc` snippet: Haddock function documentation with smart signature detection.
+  Automatically detects function name and type signature from the line below cursor,
+  generating example placeholders with parameter types.
+- `mdoc` snippet: Haddock module documentation with smart module name detection.
+  Uses LSP codelens or filename as fallback.
+- `util.parse_type_signature`: Parse Haskell type signatures into parameter types
+  and return type, handling parentheses, brackets, and braces.
+- `util.parse_function_line`: Parse function type declaration lines.
+- `util.get_function_context`: Get function context from the line below cursor.
+- `util.strip_forall`: Strip forall quantifiers from type signatures.
+- `util.strip_constraints`: Strip type class constraints from type signatures.
+- `util.is_signature_continuation`: Detect multiline signature continuation lines.
+- `util.collect_multiline_signature`: Collect multiline type signatures.
+- Multiline type signature support for `fdoc` snippet.
+- Comprehensive tests for signature parsing, forall/constraint handling,
+  multiline signatures, and function context detection (49 tests).
+
+### Fixed
+
+- Handle nil parent position in `_indent_newline` that caused
+  "bad argument #2 to 'rep'" errors in snippets using dynamic indentation.
+
 ## [1.5.0] - 2025-10-06
 
 ### Added

--- a/lua/haskell-snippets/functions.lua
+++ b/lua/haskell-snippets/functions.lua
@@ -113,4 +113,48 @@ functions.lambda = s({
 })
 table.insert(functions.all, functions.lambda)
 
+local function get_fdoc_nodes()
+  local context = util.get_function_context()
+
+  if context then
+    local nodes = {
+      text('-- | `' .. context.name .. '` '),
+      insert(1, 'description.'),
+      text { '', '--', '-- Examples:', '--', '-- >>> ' .. context.name },
+    }
+
+    -- Add each parameter as an insert node
+    local idx = 2
+    for _, param in ipairs(context.params) do
+      table.insert(nodes, text(' '))
+      table.insert(nodes, insert(idx, param))
+      idx = idx + 1
+    end
+
+    table.insert(nodes, text { '', '-- ' })
+    table.insert(nodes, insert(idx, context.return_type))
+
+    return sn(nil, nodes)
+  end
+
+  -- Fallback to placeholders
+  return sn(nil, {
+    text('-- | '),
+    insert(1, 'Brief description.'),
+    text { '', '--', '-- Examples:', '--', '-- >>> ' },
+    insert(2, 'example'),
+    text { '', '-- ' },
+    insert(3, 'expected'),
+  })
+end
+
+---@type Snippet Haddock function documentation
+functions.fdoc = s({
+  trig = 'fdoc',
+  dscr = 'Haddock function documentation',
+}, {
+  dynamic(1, get_fdoc_nodes),
+})
+table.insert(functions.all, functions.fdoc)
+
 return functions

--- a/lua/haskell-snippets/module.lua
+++ b/lua/haskell-snippets/module.lua
@@ -174,4 +174,27 @@ if has_haskell_parser then
   })
   table.insert(module.all, module.qualc)
 end
+
+local function get_mdoc_module_name_node()
+  local module_name = util.lsp_get_module_name() or get_buf_module_name()
+  if module_name then
+    return sn(nil, { text(module_name) })
+  end
+  return sn(nil, { insert(1, 'MyModule') })
+end
+
+---@type Snippet Haddock module documentation
+module.mdoc = s({
+  trig = 'mdoc',
+  dscr = 'Haddock module documentation',
+}, {
+  text { '-- |', '-- Module      : ' },
+  dynamic(1, get_mdoc_module_name_node),
+  text { '', '-- Description : ' },
+  insert(2, 'Short description here'),
+  text { '', '--', '-- ' },
+  insert(3, 'Longer description of the module.'),
+})
+table.insert(module.all, module.mdoc)
+
 return module

--- a/lua/haskell-snippets/util.lua
+++ b/lua/haskell-snippets/util.lua
@@ -9,10 +9,16 @@
 ---@brief ]]
 local util = {}
 
-local ls = require('luasnip')
-local sn = ls.snippet_node
-local text = ls.text_node
-local insert = ls.insert_node
+-- Lazy-load luasnip to allow testing pure functions without luasnip installed
+local ls, sn, text, insert
+local function ensure_luasnip()
+  if not ls then
+    ls = require('luasnip')
+    sn = ls.snippet_node
+    text = ls.text_node
+    insert = ls.insert_node
+  end
+end
 
 local function cur_buf_opt(name)
   ---@diagnostic disable-next-line
@@ -34,18 +40,16 @@ end
 ---@param extra_indent boolean?
 local function _indent_newline(mk_node, extra_indent, _, parent)
   extra_indent = extra_indent == nil or extra_indent
-  local _, pos = pcall(function()
-    -- XXX: Hack to work around below bug
+  local ok, pos = pcall(function()
     return parent:get_buf_position()
   end)
-  -- FIXME: This prints an error
-  -- local pos = parent:get_buf_position()
-  local indent_count = pos[2]
+  local indent_count = (ok and pos and pos[2]) or 0
   local indent_str = string.rep(' ', indent_count) .. (extra_indent and util.indent_str() or '')
   return mk_node(indent_str)
 end
 
 function util.indent_newline_text(txt, extra_indent)
+  ensure_luasnip()
   local function mk_node(indent_str)
     return sn(nil, { text { '', indent_str .. txt } })
   end
@@ -55,6 +59,7 @@ function util.indent_newline_text(txt, extra_indent)
 end
 
 function util.indent_newline_insert(txt, extra_indent)
+  ensure_luasnip()
   local function mk_node(indent_str)
     return sn(nil, {
       text { '', indent_str },
@@ -83,6 +88,272 @@ function util.lsp_get_module_name()
       end
     end
   end
+end
+
+--- Strip forall quantifier from a type signature.
+--- e.g., "forall a b. a -> b -> c" becomes "a -> b -> c"
+---@param signature string
+---@return string stripped signature without forall
+function util.strip_forall(signature)
+  -- Match: forall <type vars separated by spaces> . <rest>
+  -- Also handles: forall a. forall b. (nested foralls)
+  local result = signature
+  while true do
+    local stripped = result:match('^%s*forall%s+[^.]+%.%s*(.+)$')
+    if stripped then
+      result = stripped
+    else
+      break
+    end
+  end
+  return result
+end
+
+--- Strip type class constraints from a type signature.
+--- e.g., "Show a => a -> String" becomes "a -> String"
+--- e.g., "(Show a, Eq b) => a -> b -> Bool" becomes "a -> b -> Bool"
+---@param signature string
+---@return string stripped signature without constraints
+function util.strip_constraints(signature)
+  -- Match: <constraint(s)> => <rest>
+  -- Handles both single constraints and tuple constraints
+  local depth = 0
+  local i = 1
+  local len = #signature
+
+  while i <= len do
+    local char = signature:sub(i, i)
+
+    if char == '(' or char == '[' or char == '{' then
+      depth = depth + 1
+    elseif char == ')' or char == ']' or char == '}' then
+      depth = depth - 1
+    elseif depth == 0 and signature:sub(i, i + 3) == ' => ' then
+      -- Found constraint arrow at depth 0
+      return signature:sub(i + 4):match('^%s*(.+)$') or ''
+    end
+    i = i + 1
+  end
+
+  return signature
+end
+
+--- Normalize a type signature by removing forall and constraints.
+---@param signature string
+---@return string normalized signature
+function util.normalize_signature(signature)
+  local result = util.strip_forall(signature)
+  result = util.strip_constraints(result)
+  return result
+end
+
+--- Parse a Haskell type signature into parameter types and return type.
+--- Handles parenthesized types like `(Int -> Int)` as single units.
+--- Automatically strips forall quantifiers and type class constraints.
+---@param signature string e.g., "Int -> String -> Bool"
+---@return string[] params e.g., {"Int", "String"}
+---@return string return_type e.g., "Bool"
+function util.parse_type_signature(signature)
+  -- Normalize: strip forall and constraints first
+  signature = util.normalize_signature(signature)
+  local types = {}
+  local current = ''
+  local depth = 0
+  local i = 1
+  local len = #signature
+
+  while i <= len do
+    local char = signature:sub(i, i)
+
+    if char == '(' or char == '[' or char == '{' then
+      depth = depth + 1
+      current = current .. char
+      i = i + 1
+    elseif char == ')' or char == ']' or char == '}' then
+      depth = depth - 1
+      current = current .. char
+      i = i + 1
+    elseif depth == 0 and signature:sub(i, i + 3) == ' -> ' then
+      -- Found arrow at depth 0
+      local trimmed = current:match('^%s*(.-)%s*$')
+      if trimmed and #trimmed > 0 then
+        table.insert(types, trimmed)
+      end
+      current = ''
+      i = i + 4 -- Skip ' -> '
+    else
+      current = current .. char
+      i = i + 1
+    end
+  end
+
+  -- Add the last type (return type)
+  local trimmed = current:match('^%s*(.-)%s*$')
+  if trimmed and #trimmed > 0 then
+    table.insert(types, trimmed)
+  end
+
+  if #types == 0 then
+    return {}, ''
+  elseif #types == 1 then
+    return {}, types[1]
+  else
+    local return_type = table.remove(types)
+    return types, return_type
+  end
+end
+
+--- Parse a Haskell function type declaration line.
+---@param line string e.g., "funcName :: Int -> String -> Bool"
+---@return table|nil {name: string, params: string[], return_type: string}
+function util.parse_function_line(line)
+  local name, signature = line:match("^%s*([%w_']+)%s*::%s*(.+)$")
+  if not name or not signature then
+    return nil
+  end
+  local params, return_type = util.parse_type_signature(signature)
+  return {
+    name = name,
+    params = params,
+    return_type = return_type,
+  }
+end
+
+--- Check if a line is a continuation of a type signature.
+--- Continuation lines are indented and don't start a new declaration.
+---@param line string
+---@param allow_double_colon boolean? Allow :: on continuation (for name-only first line)
+---@return boolean
+function util.is_signature_continuation(line, allow_double_colon)
+  -- Must be indented (starts with whitespace)
+  if not line:match('^%s+') then
+    return false
+  end
+  -- Must not be a new declaration (no ::) unless explicitly allowed
+  if line:match('::') and not allow_double_colon then
+    return false
+  end
+  -- Must not be a function definition (no = at start after trimming, unless inside parens)
+  local trimmed = line:match('^%s*(.-)%s*$')
+  -- Check for common non-continuation patterns
+  if trimmed:match("^[%w_']+%s+[%w_']+%s*=") then
+    return false -- function definition like "f x = ..."
+  end
+  if trimmed:match('^|') then
+    return false -- guard
+  end
+  if trimmed:match('^where%s') or trimmed == 'where' then
+    return false -- where clause
+  end
+  -- Likely a continuation if starts with -> or contains type-like content
+  return true
+end
+
+--- Collect a potentially multiline type signature starting from a given row.
+--- Supports two formats:
+---   1. name :: Type -> Type (standard)
+---   2. name\n  :: Type -> Type (name on separate line)
+---@param start_row number 1-indexed row number
+---@return string|nil full_signature The complete signature (joined)
+---@return string|nil name The function name
+function util.collect_multiline_signature(start_row)
+  local line_count = vim.api.nvim_buf_line_count(0)
+
+  if start_row > line_count then
+    return nil, nil
+  end
+
+  local first_line = vim.api.nvim_buf_get_lines(0, start_row - 1, start_row, false)[1]
+  if not first_line then
+    return nil, nil
+  end
+
+  local name, signature_start, current_row
+
+  -- Try format 1: "name :: signature" on same line
+  name, signature_start = first_line:match("^%s*([%w_']+)%s*::%s*(.*)$")
+
+  if name then
+    -- Standard format: name and :: on same line
+    current_row = start_row + 1
+  else
+    -- Try format 2: name alone, then ":: signature" on next indented line
+    name = first_line:match("^%s*([%w_']+)%s*$")
+    if not name then
+      return nil, nil
+    end
+
+    -- Check if next line starts with ::
+    if start_row >= line_count then
+      return nil, nil
+    end
+
+    local second_line = vim.api.nvim_buf_get_lines(0, start_row, start_row + 1, false)[1]
+    if not second_line then
+      return nil, nil
+    end
+
+    -- Next line must be indented and start with ::
+    signature_start = second_line:match('^%s+::%s*(.*)$')
+    if not signature_start then
+      return nil, nil
+    end
+
+    current_row = start_row + 2
+  end
+
+  -- Collect continuation lines
+  local signature_parts = { signature_start }
+
+  while current_row <= line_count do
+    local next_line = vim.api.nvim_buf_get_lines(0, current_row - 1, current_row, false)[1]
+    if not next_line or not util.is_signature_continuation(next_line) then
+      break
+    end
+    -- Trim and add the continuation
+    local trimmed = next_line:match('^%s*(.-)%s*$')
+    table.insert(signature_parts, trimmed)
+    current_row = current_row + 1
+  end
+
+  -- Join all parts with space (normalizing whitespace)
+  local full_signature = table.concat(signature_parts, ' ')
+  -- Clean up multiple spaces
+  full_signature = full_signature:gsub('%s+', ' ')
+  -- Trim leading/trailing whitespace
+  full_signature = full_signature:match('^%s*(.-)%s*$')
+
+  if not full_signature or full_signature == '' then
+    return nil, nil
+  end
+
+  return full_signature, name
+end
+
+--- Get function context from the line below the cursor.
+--- Supports multiline type signatures.
+---@return table|nil {name: string, params: string[], return_type: string}
+function util.get_function_context()
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local row = cursor[1]
+  local line_count = vim.api.nvim_buf_line_count(0)
+
+  if row >= line_count then
+    return nil
+  end
+
+  -- Try to collect multiline signature starting from line below cursor
+  local signature, name = util.collect_multiline_signature(row + 1)
+  if not signature or not name then
+    return nil
+  end
+
+  local params, return_type = util.parse_type_signature(signature)
+  return {
+    name = name,
+    params = params,
+    return_type = return_type,
+  }
 end
 
 return util

--- a/tests/util_spec.lua
+++ b/tests/util_spec.lua
@@ -1,0 +1,405 @@
+describe('util', function()
+  local util = require('haskell-snippets.util')
+
+  describe('strip_forall', function()
+    it('strips simple forall', function()
+      assert.equals('a -> a', util.strip_forall('forall a. a -> a'))
+    end)
+
+    it('strips forall with multiple type vars', function()
+      assert.equals('a -> b -> c', util.strip_forall('forall a b c. a -> b -> c'))
+    end)
+
+    it('strips nested forall', function()
+      assert.equals('a -> b', util.strip_forall('forall a. forall b. a -> b'))
+    end)
+
+    it('returns unchanged if no forall', function()
+      assert.equals('Int -> Int', util.strip_forall('Int -> Int'))
+    end)
+
+    it('handles leading whitespace', function()
+      assert.equals('a -> a', util.strip_forall('  forall a. a -> a'))
+    end)
+  end)
+
+  describe('strip_constraints', function()
+    it('strips simple constraint', function()
+      assert.equals('a -> String', util.strip_constraints('Show a => a -> String'))
+    end)
+
+    it('strips tuple constraints', function()
+      assert.equals('a -> b -> Bool', util.strip_constraints('(Show a, Eq b) => a -> b -> Bool'))
+    end)
+
+    it('returns unchanged if no constraint', function()
+      assert.equals('Int -> Int', util.strip_constraints('Int -> Int'))
+    end)
+
+    it('handles constraint with parens in type', function()
+      assert.equals('(a, b) -> c', util.strip_constraints('Show a => (a, b) -> c'))
+    end)
+  end)
+
+  describe('is_signature_continuation', function()
+    it('returns true for indented arrow line', function()
+      assert.is_true(util.is_signature_continuation('  -> Int'))
+    end)
+
+    it('returns true for indented type', function()
+      assert.is_true(util.is_signature_continuation('  Int'))
+    end)
+
+    it('returns false for non-indented line', function()
+      assert.is_false(util.is_signature_continuation('-> Int'))
+    end)
+
+    it('returns false for new declaration', function()
+      assert.is_false(util.is_signature_continuation('  f :: Int'))
+    end)
+
+    it('returns false for function definition', function()
+      assert.is_false(util.is_signature_continuation('  f x = x'))
+    end)
+
+    it('returns false for guard', function()
+      assert.is_false(util.is_signature_continuation('  | x > 0 = 1'))
+    end)
+
+    it('returns false for where clause', function()
+      assert.is_false(util.is_signature_continuation('  where'))
+    end)
+  end)
+
+  describe('parse_type_signature', function()
+    it('parses simple signature', function()
+      local params, ret = util.parse_type_signature('Int -> Int')
+      assert.are.same({ 'Int' }, params)
+      assert.equals('Int', ret)
+    end)
+
+    it('parses multi-param signature', function()
+      local params, ret = util.parse_type_signature('Int -> String -> Bool')
+      assert.are.same({ 'Int', 'String' }, params)
+      assert.equals('Bool', ret)
+    end)
+
+    it('handles type applications', function()
+      local params, ret = util.parse_type_signature('Maybe Int -> IO String')
+      assert.are.same({ 'Maybe Int' }, params)
+      assert.equals('IO String', ret)
+    end)
+
+    it('handles parenthesized function types', function()
+      local params, ret = util.parse_type_signature('(Int -> Int) -> Int')
+      assert.are.same({ '(Int -> Int)' }, params)
+      assert.equals('Int', ret)
+    end)
+
+    it('handles nested parentheses', function()
+      local params, ret = util.parse_type_signature('((a -> b) -> c) -> Maybe d -> IO ()')
+      assert.are.same({ '((a -> b) -> c)', 'Maybe d' }, params)
+      assert.equals('IO ()', ret)
+    end)
+
+    it('handles single type (no arrow)', function()
+      local params, ret = util.parse_type_signature('Int')
+      assert.are.same({}, params)
+      assert.equals('Int', ret)
+    end)
+
+    it('handles constraints by stripping them', function()
+      local params, ret = util.parse_type_signature('Show a => a -> String')
+      assert.are.same({ 'a' }, params)
+      assert.equals('String', ret)
+    end)
+
+    it('handles multiple constraints', function()
+      local params, ret = util.parse_type_signature('(Show a, Eq b) => a -> b -> Bool')
+      assert.are.same({ 'a', 'b' }, params)
+      assert.equals('Bool', ret)
+    end)
+
+    it('handles forall quantifier', function()
+      local params, ret = util.parse_type_signature('forall a. a -> a')
+      assert.are.same({ 'a' }, params)
+      assert.equals('a', ret)
+    end)
+
+    it('handles forall with multiple type variables', function()
+      local params, ret = util.parse_type_signature('forall a b c. a -> b -> c')
+      assert.are.same({ 'a', 'b' }, params)
+      assert.equals('c', ret)
+    end)
+
+    it('handles forall with constraints', function()
+      local params, ret = util.parse_type_signature('forall a. Show a => a -> String')
+      assert.are.same({ 'a' }, params)
+      assert.equals('String', ret)
+    end)
+
+    it('handles nested forall', function()
+      local params, ret = util.parse_type_signature('forall a. forall b. a -> b -> (a, b)')
+      assert.are.same({ 'a', 'b' }, params)
+      assert.equals('(a, b)', ret)
+    end)
+
+    it('handles empty string', function()
+      local params, ret = util.parse_type_signature('')
+      assert.are.same({}, params)
+      assert.equals('', ret)
+    end)
+
+    it('handles complex nested types', function()
+      local params, ret = util.parse_type_signature('(a -> (b -> c)) -> d')
+      assert.are.same({ '(a -> (b -> c))' }, params)
+      assert.equals('d', ret)
+    end)
+
+    it('handles list types with arrows', function()
+      local params, ret = util.parse_type_signature('[Int -> Int] -> Bool')
+      assert.are.same({ '[Int -> Int]' }, params)
+      assert.equals('Bool', ret)
+    end)
+
+    it('handles record types with arrows', function()
+      local params, ret = util.parse_type_signature('{f :: Int -> Int} -> Bool')
+      assert.are.same({ '{f :: Int -> Int}' }, params)
+      assert.equals('Bool', ret)
+    end)
+  end)
+
+  describe('parse_function_line', function()
+    it('parses simple function declaration', function()
+      local result = util.parse_function_line('f :: Int -> Int')
+      assert.equals('f', result.name)
+      assert.are.same({ 'Int' }, result.params)
+      assert.equals('Int', result.return_type)
+    end)
+
+    it('parses function with multiple params', function()
+      local result = util.parse_function_line('add :: Int -> Int -> Int')
+      assert.equals('add', result.name)
+      assert.are.same({ 'Int', 'Int' }, result.params)
+      assert.equals('Int', result.return_type)
+    end)
+
+    it('parses function with underscores', function()
+      local result = util.parse_function_line('my_func :: String -> Bool')
+      assert.equals('my_func', result.name)
+      assert.are.same({ 'String' }, result.params)
+      assert.equals('Bool', result.return_type)
+    end)
+
+    it('parses function with primes', function()
+      local result = util.parse_function_line("f' :: Int -> Int")
+      assert.equals("f'", result.name)
+      assert.are.same({ 'Int' }, result.params)
+      assert.equals('Int', result.return_type)
+    end)
+
+    it('handles leading whitespace', function()
+      local result = util.parse_function_line('  helper :: a -> b')
+      assert.equals('helper', result.name)
+      assert.are.same({ 'a' }, result.params)
+      assert.equals('b', result.return_type)
+    end)
+
+    it('returns nil for non-signature lines', function()
+      assert.is_nil(util.parse_function_line('f x = x + 1'))
+      assert.is_nil(util.parse_function_line('-- comment'))
+      assert.is_nil(util.parse_function_line(''))
+      assert.is_nil(util.parse_function_line('module Foo where'))
+    end)
+
+    it('parses function with no params', function()
+      local result = util.parse_function_line('constant :: Int')
+      assert.equals('constant', result.name)
+      assert.are.same({}, result.params)
+      assert.equals('Int', result.return_type)
+    end)
+  end)
+
+  describe('get_function_context', function()
+    local function setup_buffer(lines)
+      local buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+      vim.api.nvim_set_current_buf(buf)
+      return buf
+    end
+
+    it('returns context from line below cursor', function()
+      setup_buffer { '', 'add :: Int -> Int -> Int', 'add a b = a + b' }
+      vim.api.nvim_win_set_cursor(0, { 1, 0 }) -- cursor on line 1
+
+      local context = util.get_function_context()
+      assert.is_not_nil(context)
+      assert.equals('add', context.name)
+      assert.are.same({ 'Int', 'Int' }, context.params)
+      assert.equals('Int', context.return_type)
+    end)
+
+    it('returns nil when cursor is on last line', function()
+      setup_buffer { 'f :: Int -> Int', 'f x = x' }
+      vim.api.nvim_win_set_cursor(0, { 2, 0 }) -- cursor on last line
+
+      local context = util.get_function_context()
+      assert.is_nil(context)
+    end)
+
+    it('returns nil when next line is not a signature', function()
+      setup_buffer { '-- documentation', 'f x = x + 1' }
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      local context = util.get_function_context()
+      assert.is_nil(context)
+    end)
+
+    it('returns nil for empty buffer', function()
+      setup_buffer { '' }
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      local context = util.get_function_context()
+      assert.is_nil(context)
+    end)
+
+    it('handles complex signatures', function()
+      setup_buffer { '', 'transform :: (a -> b) -> [a] -> [b]' }
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      local context = util.get_function_context()
+      assert.is_not_nil(context)
+      assert.equals('transform', context.name)
+      assert.are.same({ '(a -> b)', '[a]' }, context.params)
+      assert.equals('[b]', context.return_type)
+    end)
+
+    it('handles multiline signature', function()
+      setup_buffer {
+        '',
+        'longFunction :: Int',
+        '  -> String',
+        '  -> Bool',
+        'longFunction x y = x > 0',
+      }
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      local context = util.get_function_context()
+      assert.is_not_nil(context)
+      assert.equals('longFunction', context.name)
+      assert.are.same({ 'Int', 'String' }, context.params)
+      assert.equals('Bool', context.return_type)
+    end)
+
+    it('handles multiline signature with forall', function()
+      setup_buffer {
+        '',
+        'polymorphic :: forall a b.',
+        '  a -> b -> (a, b)',
+        'polymorphic x y = (x, y)',
+      }
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      local context = util.get_function_context()
+      assert.is_not_nil(context)
+      assert.equals('polymorphic', context.name)
+      assert.are.same({ 'a', 'b' }, context.params)
+      assert.equals('(a, b)', context.return_type)
+    end)
+
+    it('handles multiline signature with constraints', function()
+      setup_buffer {
+        '',
+        'showIt :: Show a =>',
+        '  a -> String',
+        'showIt = show',
+      }
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      local context = util.get_function_context()
+      assert.is_not_nil(context)
+      assert.equals('showIt', context.name)
+      assert.are.same({ 'a' }, context.params)
+      assert.equals('String', context.return_type)
+    end)
+
+    it('stops at function definition', function()
+      setup_buffer {
+        '',
+        'f :: Int -> Int',
+        'f x = x + 1',
+        'g :: String',
+      }
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      local context = util.get_function_context()
+      assert.is_not_nil(context)
+      assert.equals('f', context.name)
+      assert.are.same({ 'Int' }, context.params)
+      assert.equals('Int', context.return_type)
+    end)
+
+    it('handles signature with forall and constraints', function()
+      setup_buffer {
+        '',
+        'complicated :: forall a. Show a => a -> String',
+      }
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      local context = util.get_function_context()
+      assert.is_not_nil(context)
+      assert.equals('complicated', context.name)
+      assert.are.same({ 'a' }, context.params)
+      assert.equals('String', context.return_type)
+    end)
+
+    it('handles name on separate line from ::', function()
+      setup_buffer {
+        '',
+        'fmap',
+        '  :: (a -> b)',
+        '  -> f a',
+        '  -> f b',
+        'fmap = undefined',
+      }
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      local context = util.get_function_context()
+      assert.is_not_nil(context)
+      assert.equals('fmap', context.name)
+      assert.are.same({ '(a -> b)', 'f a' }, context.params)
+      assert.equals('f b', context.return_type)
+    end)
+
+    it('handles name on separate line with forall', function()
+      setup_buffer {
+        '',
+        'traverse',
+        '  :: forall t f a b. (Traversable t, Applicative f)',
+        '  => (a -> f b)',
+        '  -> t a',
+        '  -> f (t b)',
+        'traverse = undefined',
+      }
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      local context = util.get_function_context()
+      assert.is_not_nil(context)
+      assert.equals('traverse', context.name)
+      assert.are.same({ '(a -> f b)', 't a' }, context.params)
+      assert.equals('f (t b)', context.return_type)
+    end)
+
+    it('returns nil for name alone without signature', function()
+      setup_buffer {
+        '',
+        'someFunc',
+        'someFunc = undefined',
+      }
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      local context = util.get_function_context()
+      assert.is_nil(context)
+    end)
+  end)
+end)


### PR DESCRIPTION
## Add two new snippets for generating Haddock documentation #42 

### fdoc - Function documentation snippet:
- Auto-detects function name and type signature from line below cursor
- Parses parameter types to generate example placeholders
- Supports multiline type signatures (including name on separate line)
- Strips forall quantifiers (including nested)
- Strips type class constraints (single and tuple)
- Falls back to static placeholders when no signature detected

### mdoc - Module documentation snippet:
- Auto-detects module name via LSP codelens or filename fallback
- Generates standard Haddock module header template

## Complementary

### New utility functions in util.lua:
- strip_forall: Remove forall quantifiers from signatures
- strip_constraints: Remove type class constraints
- normalize_signature: Apply both transformations
- parse_type_signature: Parse signatures into params and return type
- parse_function_line: Parse function type declaration lines
- is_signature_continuation: Detect multiline signature continuations
- collect_multiline_signature: Join multiline signatures (supports both "name :: sig" and "name\n  :: sig" formats)
- get_function_context: Get function info from line below cursor

### Fixes _indent_newline crashed with "bad argument #41 

### Includes 53 unit tests covering all new functionality.